### PR TITLE
Add canonicalize function, add ipv6 option to host() (now returns v4 …

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,22 @@ This module should become the definition of what scopes mean in ssb.
 
 ## API
 
-## `host(scope)`
+## `canonicalize(scope)`
 
-returns default host for a given scope
+There are two names used in the scuttlebutt codebase for the LAN scope: `local` and `private`.
+`canonocalize()` deals with this (and possible other aliases) by mapping both names to 'private'.
+
+The complete mapping is:
+
+```
+- device  -> device
+- local   -> private
+- private -> private
+- public  -> public
+```
+## `host(scope, opts)`
+ 
+returns default host for a given scope. Returns an IPv4 address unless opts.ipv6 is truthy.
 
 - `device` -> 'localhost'
 - `local` -> private/non-routable IP (e.g. 192.168 ...)

--- a/index.js
+++ b/index.js
@@ -1,14 +1,25 @@
 var ip = require('non-private-ip')
 
-module.exports = {
-  host: function(scope) {
-    var f = {
-      device: function () {return 'localhost'},
-      local: ip.private,
-      private: ip.private,
-      public: ip
-    }[scope]
-    if (!f) throw new Error('invalid scope: ' + scope)
-    return f()
-  }
+function canonicalize(scope) {
+  var canonicalized = {
+    device: 'device',
+    local: 'private',
+    private: 'private',
+    public: 'public'
+  }[scope]
+  if (!canonicalized) throw new Error('invalid scope: ' + scope)
+  return canonicalized
 }
+
+function host(scope, opts) {
+  opts = opts || {}
+  var family = opts.ipv6 ? 'v6' : 'v4'
+  return {
+    device: {v4: '127.0.0.1', v6: '::1'}[family],
+    private: ip.private[family],
+    public: ip[family]
+  }[canonicalize(scope)]
+}
+
+module.exports.canonicalize = canonicalize
+module.exports.host = host

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "license": "MIT",
   "dependencies": {
     "non-private-ip": "^1.4.4"
+  },
+  "devDependencies": {
+    "tape": "^4.11.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,25 @@
+var test = require('tape')
+var scopes = require('.')
+
+test('canonicalize', function(t) {
+  var allScopes = 'device local private public'.split(' ')
+  t.deepEqual(
+    allScopes.map(scopes.canonicalize), 
+    'device private private public'.split(' ')
+  )
+  t.end()
+})
+
+test('throw if scope is invalid', function(t) {
+  t.throws(function() {
+    scopes.canonicalize('this')
+  })
+  t.end()
+})
+
+test('host("device") returns ipv4 or ipv6 representation of localhost', function(t) {
+  t.equal(scopes.host('device'), '127.0.0.1')
+  t.equal(scopes.host('device', {ipv6: true}), '::1')
+  t.equal(scopes.host('device', {ipv6: false}), '127.0.0.1')
+  t.end()
+})


### PR DESCRIPTION
I ran into an issue on macOS, where multiserver's net plugin would try to bind to my private ipv6 address and failed with `EADDRUNAVAIL`. The reason could be that, implicitly, we create an ipv4 `net` server that cannot bind to v6 addresses. (We could create a v6 server however ... but I have not investigated this further)

Anyway, I was surprised that multiserver-scopes would return ipv6 addresses by default, it both (v4 and v6) are available and figured it probably shouldn't. With this PR `host()` returns v4 addresses. However, i you want an ipv6 address, you can use the new options argument, e.g.: `host('private', {ipv6: true})`

- add canonicalize function
- add ipv6 option to `host()` 
- `host()` now returns v4 by default)
- add tests